### PR TITLE
Fixes to support installation of packer version 0.10.0 and higher

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,30 +12,17 @@ class packer(
   validate_re($kernel, ['^Linux$','^FreeBSD$','^OpenBSD$','^Windows$','^Darwin$'])
   validate_string($version)
 
-  # packer version foreman is a numeric triple such as 0.6.1, 0.7.5, or 0.10.0
-  $split_version = split($version, '[.]')
-
   # Explicitly set conditions based on the version number
-  if ($split_version[0] == 0)  and 
-     ($split_version[1] < 7) { # versions 0.0.0 through 0.6.x
-    # package name and version call is different from default
+  if versioncmp($version, '0.7.0') < 0 {
     $package_name = downcase("${version}_${kernel}_${architecture}.zip")
-    $version_check = '/opt/packer/bin/packer --version'
-
-  } elsif ($split_version[0] == 0) and
-          ($split_version[1] == 7) and
-          ($split_version[2] <  5) { # versions 0.7.0 through 0.7.4
-    # package name is same as default but version call is different
+  } else {
     $package_name = downcase("packer_${version}_${kernel}_${architecture}.zip")
-    $version_check = '/opt/packer/bin/packer --version'
   }
 
-  # the following should be the default conventions going forward (0.7.5 and higher)
-  if $package_name == undef {
-      $package_name = downcase("packer_${version}_${kernel}_${architecture}.zip")
-  }
-  if $version_check == undef {
-      $version_check = '/opt/packer/bin/packer version'
+  if versioncmp($version, '0.7.5') < 0 {
+    $version_check = '/opt/packer/bin/packer --version'
+  } else {
+    $version_check = '/opt/packer/bin/packer version'
   }
 
   # url to retrieve the packer installation package
@@ -54,8 +41,9 @@ class packer(
 
   exec { 'check_version_change':
     path    => "/bin",
-    command => "/usr/bin/test -f ${install_dir}/packer && rm ${install_dir}/packer*; return 0",
-    unless  => "/bin/bash -c 'packer_version=\$($version_check | sed -nre \"s/^Packer v[^0-9]*(([0-9]+\\.)*[0-9]+).*/\\1/p\"); if [ \$packer_version = ${version} ]; then exit 0; else exit 1; fi'"
+    command => "rm -f ${install_dir}/packer*",
+    unless  => "/bin/bash -c 'packer_version=\$($version_check | sed -nre \"s/^Packer v[^0-9]*(([0-9]+\\.)*[0-9]+).*/\\1/p\"); if [ \$packer_version = ${version} ]; then exit 0; else exit 1; fi'",
+    require => Package['unzip'],
   } ->
   staging::file { $package_name: source => $full_url, } ->
   staging::extract { $package_name:


### PR DESCRIPTION
Fixed puppet module to support versions 0.10.0 and higher of packer installation. The code to set the packer install package name and
version check command line were doing string comparisons instead of
number comparisons on the major, minor, bug fix subversions.  This
caused the code to configure package 0.10.0 as if it was 0.6.x or
earlier.  The string '0.10' is less than '0.7' but the version
numbers are not.

Fixed the packer install to continue on failure to remove the
old packer binary.  This was preventing the packer install from
completing on a freshly built box.
