### PR TITLE
fix for archives with folders

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,7 +41,7 @@ class packer(
 
   exec { 'check_version_change':
     path    => "/bin",
-    command => "rm -f ${install_dir}/packer*",
+    command => "rm -rf ${install_dir}/packer*",
     unless  => "/bin/bash -c 'packer_version=\$($version_check | sed -nre \"s/^Packer v[^0-9]*(([0-9]+\\.)*[0-9]+).*/\\1/p\"); if [ \$packer_version = ${version} ]; then exit 0; else exit 1; fi'",
     require => Package['unzip'],
   } ->


### PR DESCRIPTION
```
Error: /Stage[main]/Packer/Exec[check_version_change]/returns: change from notrun to 0 failed: rm -f /opt/packer/bin/packer* returned 1 instead of one of [0]

rm: cannot remove '/opt/packer/bin/packer-1.3.5': Is a directory
```