### PR TITLE
update owner for staging dir

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,8 +31,8 @@ class packer(
   if !defined(Class['staging']) {
     class { 'staging':
       path => '/var/staging',
-      owner => 'puppet',
-      group => 'puppet',
+      owner => 'root',
+      group => 'root',
     }
   }
 


### PR DESCRIPTION
Jenkins agents have started complaining about missing user *puppet*
```
Info: Applying configuration version '1561562637'
Error: Could not find user puppet
Info: Unknown failure using insync_values? on type: File[/var/staging] / property: owner to compare values ["puppet"] and 0
Error: /Stage[main]/Staging/File[/var/staging]/owner: change from 'root' to 'puppet' failed: Could not find user puppet
Error: Could not find group puppet
Info: Unknown failure using insync_values? on type: File[/var/staging] / property: group to compare values ["puppet"] and 0
Error: /Stage[main]/Staging/File[/var/staging]/group: change from 'root' to 'puppet' failed: Could not find group puppet
```
